### PR TITLE
Add markdown preview script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@
 2. 在草稿中保留修改前版本
 3. 标注修改原因和AI服务来源
 
+## 工具脚本
+
+如需在浏览器中预览任何 Markdown 文件，可运行 `scripts/md_preview.py`：
+
+```bash
+python scripts/md_preview.py OUTLINE.md
+```
+
+脚本会优先调用 `pandoc` 生成 HTML，若未安装则退回到 `python-markdown` 模块，并在 `http://localhost:8000` 启动简易服务器。
+
 ## 贡献指南
 
 - 所有创作内容遵循 `styleguide.md` 规范

--- a/scripts/md_preview.py
+++ b/scripts/md_preview.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Simple Markdown preview server."""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import webbrowser
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+
+def pandoc_convert(md_path: str, html_path: str) -> bool:
+    """Convert markdown to HTML via pandoc if available."""
+    try:
+        subprocess.run([
+            "pandoc",
+            md_path,
+            "-s",
+            "-o",
+            html_path,
+        ], check=True)
+        return True
+    except FileNotFoundError:
+        return False
+    except subprocess.CalledProcessError:
+        print("Pandoc failed to convert the file", file=sys.stderr)
+        return False
+
+
+def builtin_convert(md_path: str, html_path: str) -> bool:
+    """Fallback converter using python-markdown."""
+    try:
+        import markdown
+    except ImportError:
+        print("Missing 'markdown' package. Install with 'pip install markdown'.")
+        return False
+
+    with open(md_path, "r", encoding="utf-8") as f:
+        text = f.read()
+    html = markdown.markdown(text, output_format="html5")
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(html)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Preview markdown as HTML")
+    parser.add_argument("file", help="Markdown file to preview")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for HTTP server",
+    )
+    args = parser.parse_args()
+
+    md = args.file
+    if not os.path.exists(md):
+        parser.error(f"{md} does not exist")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        html = os.path.join(tmp, "index.html")
+        if not pandoc_convert(md, html):
+            print("Pandoc not found or failed. Falling back to python-markdown.")
+            if not builtin_convert(md, html):
+                return 1
+
+        os.chdir(tmp)
+        url = f"http://localhost:{args.port}/index.html"
+        webbrowser.open(url)
+        print(f"Serving preview at {url} (Ctrl+C to stop)")
+        server = HTTPServer(("localhost", args.port), SimpleHTTPRequestHandler)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/md_preview.py` for viewing markdown in the browser
- document usage in README

## Testing
- `python scripts/md_preview.py OUTLINE.md`

------
https://chatgpt.com/codex/tasks/task_e_6843097d567483308846755d7f0f0b3f